### PR TITLE
Minor improvement to smear_plotter.py 

### DIFF
--- a/smearing_code/smear_plotter.py
+++ b/smearing_code/smear_plotter.py
@@ -86,8 +86,9 @@ for iline in infile.readlines():
         continue # this is a header line, move on
     else:
         rowvals = find_between(iline, "{", "}")
-        rowvals_str = rowvals.split(",")[2:]
-        smearrows.append([float(x) for x in rowvals_str]) # first two entries don't really matter for this
+        if len(rowvals) > 0:
+            rowvals_str = rowvals.split(",")[2:]
+            smearrows.append([float(x) for x in rowvals_str]) # first two entries don't really matter for this
     if ";" in iline:
         # this is the last one
         break


### PR DESCRIPTION
Due to its parsing of the input, `smear_plotter.py` was not compatible with files produced by `create_smearing_matrix.py` as the second row `@energy =\n` was interpreted as a data row. By checking that there is at least something within the expected delimiters, this allows to read all the files.