### PR TITLE
Infrastructure to publish data files as PyPI package

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,0 +1,50 @@
+# This workflows will upload a Python Package using Twine when a release is published
+# Based on https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Publish to PyPI
+
+on:
+  push:
+    branches:
+      - 'pythonPackaging'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Build and test
+      id: build_test
+      run: |
+        cd snowglobes_data/
+        # Build and install
+        ./setup.sh
+        pip install dist/snowglobes_data-*.whl
+        # Check the module imports successfully and that the version is what we expect
+        PYTHON_VERSION=`python -c 'import snowglobes_data; print(snowglobes_data.__version__)'`
+        GIT_VERSION=${GITHUB_REF/refs\/tags\//}
+        echo "PYTHON_VERSION=${PYTHON_VERSION}"
+        echo "GIT_VERSION=${GIT_VERSION}"
+        # if [ $PYTHON_VERSION != $GIT_VERSION ]; then exit 1; fi
+        echo "VERSION=${PYTHON_VERSION}" >> $GITHUB_OUTPUT
+
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+    - name: Create draft release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.build_test.outputs.VERSION }}
+        draft: true
+        prerelease: false
+        generate_release_notes: true

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -5,14 +5,16 @@ name: Publish to PyPI
 
 on:
   push:
-    branches:
-      - 'pythonPackaging'
+    tags: # Sequence of patterns matched against refs/tags
+      - 'v*' # Any tag matching v*, e.g. v1.0, v1.2b1
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     permissions:
+      # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
       id-token: write
+      contents: read
 
     steps:
     - uses: actions/checkout@v3
@@ -25,21 +27,23 @@ jobs:
       id: build_test
       run: |
         cd snowglobes_data/
+        GIT_VERSION=${GITHUB_REF/refs\/tags\/v/}
+
         # Build and install
-        ./setup.sh
+        GIT_VERSION=$GIT_VERSION ./build.sh
         pip install dist/snowglobes_data-*.whl
+
         # Check the module imports successfully and that the version is what we expect
         PYTHON_VERSION=`python -c 'import snowglobes_data; print(snowglobes_data.__version__)'`
-        GIT_VERSION=${GITHUB_REF/refs\/tags\//}
         echo "PYTHON_VERSION=${PYTHON_VERSION}"
         echo "GIT_VERSION=${GIT_VERSION}"
-        # if [ $PYTHON_VERSION != $GIT_VERSION ]; then exit 1; fi
+        if [ $PYTHON_VERSION != $GIT_VERSION ]; then exit 1; fi
         echo "VERSION=${PYTHON_VERSION}" >> $GITHUB_OUTPUT
 
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository-url: https://test.pypi.org/legacy/
+        packages-dir: snowglobes_data/dist/
 
     - name: Create draft release
       uses: softprops/action-gh-release@v1

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,11 @@
 **/.ipynb_checkpoints
 **/.virtual_documents
 
-# old giignore (SNOwGLoBES 1.2)
+# Build directories for Python wheel
+/snowglobes_data/dist/
+/snowglobes_data/src/
+
+# old gitignore (SNOwGLoBES 1.2)
 bin/supernova
 out/*.dat
 plots/*.root

--- a/snowglobes_data/README.md
+++ b/snowglobes_data/README.md
@@ -1,0 +1,24 @@
+# snowglobes_data
+
+Module to make [SNOwGLoBES](https://github.com/SNOwGLoBES/snowglobes) data files available as a PyPI package.
+
+This lets any Python package install SNOwGLoBES data files as a dependency via `pip` and access them via the [`importlib.resources`](https://docs.python.org/3/library/importlib.resources.html) module.
+
+## Usage
+
+Install this package manually using
+```bash
+pip install snowglobes_data
+```
+or automatically by listing it as a dependency e.g. in the `requirements.txt` file of another Python package.
+
+You can then access the data files without cloning the SNOwGLoBES repo and manually hard-coding its path in the script:
+```Python
+from importlib.resources import files
+import snowglobes_data
+
+# Use `files(snowglobes_data)` instead of the hard-coded path to the SNOwGLoBES repo:
+with open(files(snowglobes_data).joinpath("detector_configurations.dat")) as detectors:
+    for line in detectors:
+        print(line.strip())
+```

--- a/snowglobes_data/build.sh
+++ b/snowglobes_data/build.sh
@@ -4,9 +4,11 @@
 mkdir -p src/snowglobes_data
 cp -r ../LICENSE ../detector_configurations.dat ../channels ../effic ../smear ../xscns src/snowglobes_data/
 
-# Get version number from latest git tag
-VERSION=`git describe --abbrev=0 | sed 's/v//'`
-echo "__version__ = '$VERSION'" > src/snowglobes_data/__init__.py
+# Get version number from environment variable (in GitHub Action); fall back to latest git tag for local installs
+if [ ! $GIT_VERSION ]; then
+  GIT_VERSION=`git describe --dirty | sed 's/v//'`;
+fi
+echo "__version__ = '$GIT_VERSION'" > src/snowglobes_data/__init__.py
 
 # Create __init__ files for submodules. Without these, code like `files(snowglobes_data.channels)` raises an error in importlib.resources under Python 3.9
 # See https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime

--- a/snowglobes_data/pyproject.toml
+++ b/snowglobes_data/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "snowglobes_data"
+version = "1.3"
+authors = [{name="SNOwGLoBES Contributors"}]
+description = "Data files included as part of SNOwGLoBES"
+readme = "README.md"
+requires-python = ">=3.7"
+license = {file = "LICENSE"}
+classifiers = [
+    "Private :: Do Not Upload",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+    "Operating System :: OS Independent",
+    "Topic :: Scientific/Engineering :: Physics",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/SNOwGLoBES/snowglobes"
+"Bug Tracker" = "https://github.com/SNOwGLoBES/snowglobes/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["snowglobes_data",
+           "snowglobes_data.channels",
+           "snowglobes_data.effic.*",
+           "snowglobes_data.smear.*",
+           "snowglobes_data.xscns"]
+
+[tool.setuptools.package-data]
+"*" = ["*.dat"]

--- a/snowglobes_data/pyproject.toml
+++ b/snowglobes_data/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "snowglobes_data"
-version = "1.3"
+dynamic = ["version"]
 authors = [{name="SNOwGLoBES Contributors"}]
 description = "Data files included as part of SNOwGLoBES"
 readme = "README.md"
@@ -21,6 +21,9 @@ classifiers = [
 [project.urls]
 "Homepage" = "https://github.com/SNOwGLoBES/snowglobes"
 "Bug Tracker" = "https://github.com/SNOwGLoBES/snowglobes/issues"
+
+[tool.setuptools.dynamic]
+version = {attr = "snowglobes_data.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/snowglobes_data/setup.sh
+++ b/snowglobes_data/setup.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+# Set up directory structure for a Python package
+mkdir -p src/snowglobes_data
+cp -r ../LICENSE ../detector_configurations.dat ../channels ../effic ../smear ../xscns src/snowglobes_data/
+
+# Build package using configurations in pyproject.toml
+pip install --upgrade build
+python -m build

--- a/snowglobes_data/setup.sh
+++ b/snowglobes_data/setup.sh
@@ -4,6 +4,10 @@
 mkdir -p src/snowglobes_data
 cp -r ../LICENSE ../detector_configurations.dat ../channels ../effic ../smear ../xscns src/snowglobes_data/
 
+# Create __init__ files for submodules. Without these, code like `files(snowglobes_data.channels)` raises an error in importlib.resources under Python 3.9
+# See https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime
+touch src/snowglobes_data/__init__.py src/snowglobes_data/channels/__init__.py src/snowglobes_data/effic/__init__.py src/snowglobes_data/smear/__init__.py src/snowglobes_data/xscns/__init__.py
+
 # Build package using configurations in pyproject.toml
 pip install --upgrade build
 python -m build

--- a/snowglobes_data/setup.sh
+++ b/snowglobes_data/setup.sh
@@ -4,6 +4,10 @@
 mkdir -p src/snowglobes_data
 cp -r ../LICENSE ../detector_configurations.dat ../channels ../effic ../smear ../xscns src/snowglobes_data/
 
+# Get version number from latest git tag
+VERSION=`git describe --abbrev=0 | sed 's/v//'`
+echo "__version__ = '$VERSION'" > src/snowglobes_data/__init__.py
+
 # Create __init__ files for submodules. Without these, code like `files(snowglobes_data.channels)` raises an error in importlib.resources under Python 3.9
 # See https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime
 touch src/snowglobes_data/__init__.py src/snowglobes_data/channels/__init__.py src/snowglobes_data/effic/__init__.py src/snowglobes_data/smear/__init__.py src/snowglobes_data/xscns/__init__.py


### PR DESCRIPTION
This PR contains the basic infrastructure to publish a package with the SNOwGLoBES data files (`detector_configurations.dat` and the directories `channels/`, `effic/`, `smear/` and `xscns/`) to PyPI.

This makes it easier to reuse these files. For example, in [SNEWPY](https://github.com/SNEWS2/snewpy/issues/208) users currently need to manually download SNOwGLoBES and specify the SNOwGLoBES directory in every function call (or set the environment variable). With this PR and the corresponding changes to SNEWPY, this would all be handled automatically by the package manager.

As you can this in this PR, no changes to existing SNOwGLoBES code, files or directory structure is required. The additions are in a single `snowglobes_data/` directory; simply run the `setup.sh` script in there to generate the package.
In a future commit, I can add a GitHub workflow which automatically generates the package and uploads it to PyPI whenever a new SNOwGLoBES version is tagged.