### PR TITLE
fix `snowglobes_data` build script

### DIFF
--- a/snowglobes_data/build.sh
+++ b/snowglobes_data/build.sh
@@ -6,7 +6,7 @@ cp -r ../LICENSE ../detector_configurations.dat ../channels ../effic ../smear ..
 
 # Get version number from environment variable (in GitHub Action); fall back to latest git tag for local installs
 if [ ! $GIT_VERSION ]; then
-  GIT_VERSION=`git describe --dirty | sed 's/v//'`;
+  GIT_VERSION=`git describe --dirty | sed 's/v//' | sed 's/-/+/'`;
 fi
 echo "__version__ = '$GIT_VERSION'" > src/snowglobes_data/__init__.py
 


### PR DESCRIPTION
Fixes a small bug that could cause the `snowglobes_data` build script to fail:
```bash
> ./build.sh

[… many lines omitted …]

packaging.version.InvalidVersion: Invalid version: '1.3.2-10-gb25ec7d-dirty'
ERROR Backend subprocess exited when trying to invoke get_requires_for_build_sdist
```

Turning the first `-` in the `git describe` output into a `+` ensures that everything afterwards is considered a [local version label](https://packaging.python.org/en/latest/specifications/version-specifiers/#local-version-identifiers) where fewer restrictions apply.