### PR TITLE
Documentation updates

### DIFF
--- a/doc/tex_src/snowglobes_latest.tex
+++ b/doc/tex_src/snowglobes_latest.tex
@@ -45,6 +45,7 @@
 \author[5,1]{Nicolas Kaiser}
 \author[6]{Jim Kneller}
 \author[9]{Elise McCarthy}
+\author[11]{Jost Migenda}
 \author[1]{Alexander Moss}
 \author[7]{Diane Reitzner}
 \author[1*]{Kate Scholberg}
@@ -62,6 +63,7 @@
 \affil[8]{Department of Physics, University of Wisconsin, Madison, WI, 53706-1390}
 \affil[9]{Department of Physics and Astronomy, University of Rochester, Rochester, NY, 14620}
 \affil[10]{Department of Physics, University of Houston, Houston, TX, 77004}
+\affil[11]{e-Research, King’s College London, London, United Kingdom}
 \affil[*]{\textbf{schol@phy.duke.edu}}
 
 

--- a/doc/tex_src/snowglobes_latest.tex
+++ b/doc/tex_src/snowglobes_latest.tex
@@ -2,7 +2,7 @@
 \usepackage{authblk}
 \usepackage[utf8]{inputenc}
 \usepackage[title]{appendix}
-\usepackage{url} % for URLs in references
+\usepackage{hyperref}
 
 % Figures and graphics handling
 \usepackage{graphicx}
@@ -13,8 +13,8 @@
 \usepackage{changepage}
 \usepackage{lineno}
 \usepackage{setspace}
-\linenumbers %Switch command - turn line numbers on/off
-\doublespacing %Switch command - set spacing
+% \linenumbers %Switch command - turn line numbers on/off
+% \doublespacing %Switch command - set spacing
 
 % Highlighting
 \usepackage{xcolor}
@@ -123,24 +123,21 @@ Users familiar with version 1.2 will find all functionality they are accustomed 
 
 % -----------------------------------------------------------------------------------------
 \subsection{Dependencies}
-\snow v.~1.3 depends on \glb \cite{globes} version 3.0.15 or later (v.~3.1.6 for Mac). The environment variable \texttt{GLB\_DIR} must be set to the \glb installation directory.
+\snow depends on \glb \cite{globes} version 3.0.15 or later (v.~3.1.6 for Mac). The environment variable \texttt{GLB\_DIR} must be set to the \glb installation directory.
 
 \glb itself requires \texttt{Gnu Scientific Library} (\texttt{GSL}), particularly access to the header files. Users of RHEL-derivative Linux distributions such as CentOS and Scientific Linux should be aware that on these operating systems, the \texttt{GSL} header files do not install with the main \texttt{GSL} library. After installing \texttt{GSL} as normal, RHEL-derivative Linux users should install the \texttt{gsl-devel} package to obtain the header files.
 
-\texttt{Perl} is required to execute \snow. The cross-section file, efficiency file, and smearing matrix generation scripts require \texttt{Python}, either 2.6, 2.7, or 3.6+ depending on the script. The most current data visualization tool requires \texttt{Jupyter Notebook}, and some additional sample plotting scripts are available utilizing \texttt{ROOT} \cite{root}. 
+\texttt{Perl} is required to execute \snow. The cross-section file, efficiency file, and smearing matrix generation scripts require \texttt{Python} 3.6+. The most current data visualization tool requires \texttt{Jupyter Notebook}, and some additional sample plotting scripts are available utilizing \texttt{ROOT} \cite{root}. 
 
 The basic \snow install does \textit{not} require \texttt{ROOT}, but advanced users wishing to utilize the \cev-specific extension modules in the \texttt{/smearing\_code/dukecevns/} subdirectory will need \texttt{ROOT} for a majority of the functions. A README and a Makefile are available in this subdirectory with more specific instructions.
 
 % -----------------------------------------------------------------------------------------
 \subsection{Download and Installation Instructions}
 \begin{itemize}
-    \item Version 1.3, the most current release, is available on Github:
-
-\texttt{https://github.com/SNOwGLoBES/snowglobes}
-
+    \item Download the latest release from GitHub: \url{https://github.com/SNOwGLoBES/snowglobes}
     \item Set the environment variable \texttt{\$SNOWGLOBES} to the directory where \snow will be installed (most commonly \texttt{/home/[user]/snowglobes}).
     \item Set the environment variable \texttt{\$GLB\_DIR} to the location of \glb (most commonly \texttt{/usr/local}).
-    \item Go to \texttt{\$\snow/src/} and type \texttt{make}, then \texttt{make install}.
+    \item Go to \texttt{\$SNOWGLOBES/src/} and type \texttt{make}, then \texttt{make install}.
     \item That's it. The now fully-installed package is executed from the \texttt{\$SNOWGLOBES} directory.
 \end{itemize}
 
@@ -157,7 +154,7 @@ The \snow package has data files organized into several subdirectories:
 
 \item \texttt{\$SNOWGLOBES/doc} contains documentation for installation and running, and references for the included data files. 
 
-\item \texttt{\$SNOWGLOBES/effic} contains the post-smearing efficiency files in \glb format, labeled by interaction type and detector configuration. A Python 3.6+ script, written to generate these files for default detector configurations, is located in the main \texttt{\$SNOWGLOBES} directory.
+\item \texttt{\$SNOWGLOBES/effic} contains the post-smearing efficiency files in \glb format, labeled by interaction type and detector configuration. A Python script, written to generate these files for default detector configurations, is located in the main \texttt{\$SNOWGLOBES} directory.
 
 \item \texttt{\$SNOWGLOBES/fluxes} contains the flux files in \glb format, labeled by flux name.
 
@@ -347,7 +344,7 @@ Unlike the efficiency, including the background in a \snow simulation is optiona
 % -----------------------------------------------------------------------------------------
 \subsection{Supporting Script: \texttt{create\_effc.py}} \label{subsec:efficsupportscript}
 
-\texttt{create\_effc.py} is a Python 3.6+ script located in the \texttt{\$SNOWGLOBES} main directory.  It is provided to allow users to readily generate new efficiency files for their detector configuration.
+\texttt{create\_effc.py} is a Python script located in the \texttt{\$SNOWGLOBES} main directory.  It is provided to allow users to readily generate new efficiency files for their detector configuration.
 
 \texttt{create\_effc.py} is executed with the command \texttt{python3.6 [channel file name]}; it then directs the user to identify their detector configuration name. The script matches the configuration name to an efficiency function defined in \texttt{get\_detector\_effic()}. These are detection percentage as a function of detected energy in GeV, defined using lambda functions. 
 
@@ -460,7 +457,7 @@ The \cev cross-section of interaction is given by~\cite{patton_neutrino-nucleus_
 % -----------------------------------------------------------------------------------------
 \subsection{Supporting Scripts: Generation of Cross-Sections Files} \label{subsec:xsecsupportscripts}
 
-In the subdirectory \texttt{\$SNOWGLOBES/xscns/generic\_xs}, we provide three scripts to generate new cross-sections files. The first, \texttt{compute\_nu\_e\_cross\_sections.py}, runs with either Python 2.6 and 3.7. It requires no arguments, and generates new cross-sections files for $\nu_{e,x} + e^- \rightarrow \nu_{e,x} + e^-$ ES interactions as detailed in Sec.~\ref{subsec:nu-e-elastic}. This script is most useful in the event a $\nu_{e,x} + e^- \rightarrow \nu_{e,x} + e^-$ ES cross-section file is accidentally deleted, but an experienced user could edit it to change how the cross-section of interaction is calculated.
+In the subdirectory \texttt{\$SNOWGLOBES/xscns/generic\_xs}, we provide three scripts to generate new cross-sections files. The first, \texttt{compute\_nu\_e\_cross\_sections.py}, requires no arguments, and generates new cross-sections files for $\nu_{e,x} + e^- \rightarrow \nu_{e,x} + e^-$ ES interactions as detailed in Sec.~\ref{subsec:nu-e-elastic}. This script is most useful in the event a $\nu_{e,x} + e^- \rightarrow \nu_{e,x} + e^-$ ES cross-section file is accidentally deleted, but an experienced user could edit it to change how the cross-section of interaction is calculated.
 
 The \cev cross-sections have a number of parameters the user may wish to change - to that end, we provide \texttt{populate\_CEvNS\_xs.py}. This script is executed using the command \texttt{python3.6 populate\_CEvNS\_xs.py [form factor name]}. Allowable form factor names are Helm and Klein-Nystrand, but space has been designated for future implementation of the Horowitz/numerical and Hoferichter Form Factors. 
 
@@ -468,7 +465,7 @@ By editing the script, the user can change the relative abundance of their detec
 
 \texttt{populate\_CEvNS\_xs.py} generates 18 files by default - one cross-section file for each neutrino flavor and element - but the user can limit the script to their material of interest by commenting out the undesirable \texttt{Generate()} calls at the end of the script. To limit the script to a smaller subset of neutrino species, edit the \texttt{neutrinoname} list on line 142.
 
-The final script provided in \texttt{\$SNOWGLOBES/xscns/generic\_xs} is \texttt{universal\_xs.py}. This script will run with either Python 2.7 or 3.7; running the script without arguments will print instructions and produce an example file. This script is designed to assist in adding new interaction channels by producing ``generic" cross-sections files for charged-current interactions on arbitrary nuclei. These generic cross-sections are based on parameterizations of cross-section shape and magnitude. The magnitude parameterization was made by fitting cross sections for various materials provided in \cite{SajjadAthar:2005ke}. The parameterization takes into account the Z (proton number), A (mass number), and Q-value threshold of the reaction.  This parameterization matches the theoretical cross section predictions to within near 20\%, though the theoretical predictions themselves may be far more uncertain than that.
+The final script provided in \texttt{\$SNOWGLOBES/xscns/generic\_xs} is \texttt{universal\_xs.py}. Running the script without arguments will print instructions and produce an example file. This script is designed to assist in adding new interaction channels by producing ``generic" cross-sections files for charged-current interactions on arbitrary nuclei. These generic cross-sections are based on parameterizations of cross-section shape and magnitude. The magnitude parameterization was made by fitting cross sections for various materials provided in \cite{SajjadAthar:2005ke}. The parameterization takes into account the Z (proton number), A (mass number), and Q-value threshold of the reaction.  This parameterization matches the theoretical cross section predictions to within near 20\%, though the theoretical predictions themselves may be far more uncertain than that.
 
 The cross section parameterization is based on the cross sections provided in \snow for deuterium, \ce{^12C}, \ce{^16O}, and \ce{^40Ar}, based on Q-value threshold and mass number. Note that the thresholds used in this parameterization fit may not all be accurate.
 While the ground-state to ground-state mass difference (plus electron mass) can be a good estimate for the threshold, the reaction may tend to go to an excited state of the daughter nucleus.
@@ -486,7 +483,7 @@ Default smearing matrices are provided on install for most of the default detect
 % -----------------------------------------------------------------------------------------
 \subsection{Supporting Script: \texttt{create\_smearing\_matrix.py}} \label{subsec:csm.py}
 
-The script \texttt{create\_smearing\_matrix.py} is provided to generate new smearing matrices according to the user's needs. This script requires Python 3.6 or higher. In the \texttt{\$SNOWGLOBES/smearing\_code} directory, run 
+The script \texttt{create\_smearing\_matrix.py} is provided to generate new smearing matrices according to the user's needs. In the \texttt{\$SNOWGLOBES/smearing\_code} directory, run 
 \texttt{python3.6 create\_smearing\_matrix.py} and follow the interactive prompts,
 which explain the inputs in detail. The script can also be run with a JSON file as the sole argument.
 
@@ -663,8 +660,8 @@ Several future upgrades are planned for $\snow$:
     \item Additional form factors for \cev channels.
 \end{itemize}
 
-Bug reports, suggestions and contributions are very welcome.  Please
-contact Kate Scholberg at \texttt{schol@phy.duke.edu}.
+Bug reports, suggestions and contributions are very welcome.
+Please file an issue on the GitHub repo at \url{https://github.com/SNOwGLoBES/snowglobes/issues} or contact Kate Scholberg at \href{mailto:schol@phy.duke.edu}{schol@phy.duke.edu}.
 
 
 % -----------------------------------------------------------------------------------------
@@ -676,11 +673,16 @@ Long Baseline Neutrino Experiment collaboration, for which research activities a
 
 \begin{appendices}
 \section{Change Log}
+
+This appendix contains an overview over significant changes.
+For releases v1.3 and later, you can see detailed changelogs on GitHub at \url{https://github.com/SNOwGLoBES/snowglobes/releases}.
+
 \begin{itemize}
     \item Version 1.0 is the initial release.
     \item Version 1.1: The target weighting factors are applied automatically by \texttt{supernova.pl}. which creates correctly-weighted output event rate files from the raw unweighted files (the latter now designated unweighted.dat). Example plotting and event table scripts now no longer apply the weighting factor to event rates, and the user is no longer responsible for doing it.
     \item Version 1.2: Capacity for handling backgrounds is added; a single background rate per detector configuration is enabled, if provided by the user. A default background for the \texttt{ar17kt} configuration is included. The NC inelastic interaction cross section is added for \ce{^40Ar}.
-    \item Version 1.3: The \cev interaction channel is added for natural abundances of \ce{Ar}, \ce{Xe}, and \ce{Ge} detector materials, with instructions for the user to change the abundance. Detectors utilizing \cev, \cev cross-sections files, and new supporting code are added. User-settable energy ranges and binning resolution is now supported. The efficiency file is now a mandatory simulation component. New output visualization tools are included.
+    \item Version 1.3: The \cev interaction channel is added for natural abundances of \ce{Ar}, \ce{Xe}, and \ce{Ge} detector materials, with instructions for the user to change the abundance. Detectors utilizing \cev, \cev cross-sections files, and new supporting code are added. User-settable energy ranges and binning resolution is now supported. The efficiency file is now a mandatory simulation component. New output visualization tools are included. Support for KM3Net was added.
+    \item Version 1.3.x: \snow data files are now available as a Python package on PyPI, for easier use by third-party software like SNEWPY. Update all support scripts to Python 3. Bug fixes and minor improvements.
 \end{itemize}
 
 \section{GPL}
@@ -688,7 +690,7 @@ This program is free software: you can redistribute it and/or modify it under th
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License along with this program.  If not, see \texttt{https://www.gnu.org/licenses/}.
+You should have received a copy of the GNU General Public License along with this program.  If not, see \url{https://www.gnu.org/licenses/}.
 \end{appendices}
 
 % -----------------------------------------------------------------------------------------


### PR DESCRIPTION
* Remove some hard-coded mentions of "v1.3", where they refered generically to the current version
* Python 2.x reached end-of-life 5+ years ago and is no longer available on many modern systems, so we can stop supporting it
* consistent spelling of $SNOWGLOBES environment variable
* refer to GitHub for reporting issues and viewing release notes; update release notes for v1.3.x
* use clickable links for URLs and email address
* added myself to the author list